### PR TITLE
updated api to version 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-pipeline-operator": "^7.12.1",
-    "@cennznet/api": "1.4.0-alpha.0",
-    "@cennznet/types": "1.4.0-alpha.0",
+    "@cennznet/api": "1.4.0",
+    "@cennznet/types": "1.4.0",
     "@fortawesome/free-solid-svg-icons": "^5.9.0",
     "@polkadot/extension-dapp": "^0.36.1",
     "@polkadot/keyring": "4.2.1",

--- a/src/redux/epics/global.epic.ts
+++ b/src/redux/epics/global.epic.ts
@@ -73,7 +73,14 @@ const getExtensionMetadata = (
                         // remove all the classes from the spectypes
                         // the metadata that gets updated on the cennznet extension requires types of type (Record<string, string|object>)
                         const filteredSpecTypes = Object.keys(specTypes)
-                            .filter(key => typeof specTypes[key] !== 'function')
+                            .filter(key => {
+                                if (typeof specTypes[key] === 'function') {
+                                    // tslint:disable-next-line:no-console
+                                    console.log('extension meta update - Filtered from spec types:', specTypes[key]);
+                                    return false;
+                                }
+                                return true;
+                            })
                             .reduce((obj, key) => {
                                 obj[key] = specTypes[key];
                                 return obj;

--- a/src/redux/epics/global.epic.ts
+++ b/src/redux/epics/global.epic.ts
@@ -83,6 +83,8 @@ const getExtensionMetadata = (
                         if (specTypes.ExtrinsicPayloadV4) {
                             delete specTypes.ExtrinsicPayloadV4;
                         }
+                        delete specTypes.EnhancedTokenId;
+
                         const DEFAULT_SS58 = api.registry.createType('u32', addressDefaults.prefix);
                         const DEFAULT_DECIMALS = api.registry.createType('u32', 4);
                         const metadata = {

--- a/src/redux/epics/global.epic.ts
+++ b/src/redux/epics/global.epic.ts
@@ -71,19 +71,13 @@ const getExtensionMetadata = (
                             api.runtimeVersion.specVersion
                         );
                         // remove all the classes from the spectypes
-                        // The reason for the removal of the following object from specTypes -
-                        // the metadata that gets updated on the polkadot extension requires types of type (Record<string, string>)
-                        // It does not allow classes/objects...
-                        if (specTypes.ExtrinsicSignatureV4) {
-                            delete specTypes.ExtrinsicSignatureV4;
-                        }
-                        if (specTypes.SignerPayload) {
-                            delete specTypes.SignerPayload;
-                        }
-                        if (specTypes.ExtrinsicPayloadV4) {
-                            delete specTypes.ExtrinsicPayloadV4;
-                        }
-                        delete specTypes.EnhancedTokenId;
+                        // the metadata that gets updated on the cennznet extension requires types of type (Record<string, string|object>)
+                        const filteredSpecTypes = Object.keys(specTypes)
+                            .filter(key => typeof specTypes[key] !== 'function')
+                            .reduce((obj, key) => {
+                                obj[key] = specTypes[key];
+                                return obj;
+                            }, {});
 
                         const DEFAULT_SS58 = api.registry.createType('u32', addressDefaults.prefix);
                         const DEFAULT_DECIMALS = api.registry.createType('u32', 4);
@@ -97,7 +91,7 @@ const getExtensionMetadata = (
                             ss58Format: DEFAULT_SS58.toNumber(),
                             tokenDecimals: DEFAULT_DECIMALS.toNumber(),
                             tokenSymbol: 'CENNZ',
-                            types: (specTypes as unknown) as Record<string, string>,
+                            types: (filteredSpecTypes as unknown) as Record<string, string>,
                             userExtensions: cennznetExtensions,
                         };
                         return updateMetadata(metadata);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,12 +1579,12 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cennznet/api@1.4.0-alpha.0":
-  version "1.4.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@cennznet/api/-/api-1.4.0-alpha.0.tgz#b272bba6067b24966d13bf24b4525707dc72527b"
-  integrity sha512-RUlVfoexEn7F7yJN7tVrllNHtTZvURPoLP58VwC5zo59M8Qn45tlb72CONMS/UQc5wHavQemuHBjtXU8G839bg==
+"@cennznet/api@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@cennznet/api/-/api-1.4.0.tgz#7daeff531b2829a2d353bc401641353327932e02"
+  integrity sha512-CydSYdQpmsOaRFFsvqHdLnoXS6NcTd1f1y8oqsPf4ZsmdMUBkpPDlt3cKMTVFJEbUu5hF2XiyhWY5xG0TmUGeg==
   dependencies:
-    "@cennznet/types" "^1.4.0-alpha.0"
+    "@cennznet/types" "^1.4.0"
     "@polkadot/api" "2.7.1"
     "@polkadot/metadata" "2.7.1"
     "@polkadot/rpc-core" "2.7.1"
@@ -1592,10 +1592,10 @@
     "@polkadot/types" "2.7.1"
     eventemitter3 "^4.0.0"
 
-"@cennznet/types@1.4.0-alpha.0", "@cennznet/types@^1.4.0-alpha.0":
-  version "1.4.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@cennznet/types/-/types-1.4.0-alpha.0.tgz#3016a6d8841447185c38c81224119e6f86515c21"
-  integrity sha512-7mJMQ+WQnbQjD14zXaPzEYsgb5Ok1zE061qH9k6PC1m6KoUH90sPP+kHWny85UpnXomGDW5MDhsV4MU1ROBI1Q==
+"@cennznet/types@1.4.0", "@cennznet/types@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@cennznet/types/-/types-1.4.0.tgz#66fd5539d1ca1dd058960a3180d04fd27891c427"
+  integrity sha512-q49F21/e82eu1cBZtO56d7oNvCTQGoQWH4946/gYwM7q9DthvvBx01hsO8ld9P0Q0i4IYoPaOciL+gSxGqTGNg==
   dependencies:
     "@polkadot/keyring" "^4.2.1"
     "@polkadot/types" "2.7.1"


### PR DESCRIPTION
Update CENNZX to use the 1.4.0 version of API...
Thinking of changing this part

`
if (specTypes.ExtrinsicPayloadV4) {                      
delete specTypes.ExtrinsicPayloadV4;                       
 }                       
delete specTypes.EnhancedTokenId;`

Tried to filter the 'specTypes' object to only include when the value is of type string - but the metadata was not updated properly..
const filteredSpecTypes = Object.keys(specTypes)
    .filter(key => typeof specTypes[key] === 'string' || specTypes[key] instanceof String)
    .reduce((obj, key) => {
         obj[key] = specTypes[key];
        return obj;
   }, {});
Will get back to this in a different PR