### PR TITLE
Fix css when tx hash gets bigger

### DIFF
--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,4 +1,5 @@
 import React, {FC} from 'react';
+import styled from 'styled-components';
 
 interface ExternalLinkProps {
     url: string;
@@ -6,9 +7,19 @@ interface ExternalLinkProps {
 }
 
 const ExternalLink: FC<ExternalLinkProps> = ({url, text}) => (
-    <a href={url} target="_new">
+    <TruncateLink href={url} target="_new">
         {text}
-    </a>
+    </TruncateLink>
 );
 
 export default ExternalLink;
+
+const TruncateLink = styled.a`
+     {
+        display: inline-block;
+        width: 43rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+`;

--- a/src/pages/liquidity/validation/userBalance.ts
+++ b/src/pages/liquidity/validation/userBalance.ts
@@ -81,7 +81,7 @@ function checkUserBalanceForFee(props: LiquidityProps, errors: FormErrors): stri
     let balRequired = feeAmount;
 
     // Add core amount to the fee only for add liquidity operation
-    if (extrinsic === ADD_LIQUIDITY && coreAmount && balRequired) {
+    if (extrinsic && extrinsic === ADD_LIQUIDITY && coreAmount && balRequired) {
         balRequired = new Amount(balRequired.add(coreAmount));
     }
     const assetBalance = userAssetBalance.find(

--- a/src/pages/liquidity/validation/userBalance.ts
+++ b/src/pages/liquidity/validation/userBalance.ts
@@ -70,7 +70,7 @@ function checkUserBalance(props: LiquidityProps, errors: FormErrors): void {
 
 function checkUserBalanceForFee(props: LiquidityProps, errors: FormErrors): string {
     const {
-        form: {assetAmount, assetId, feeAssetId, coreAmount, signingAccount},
+        form: {assetAmount, assetId, feeAssetId, coreAmount, signingAccount, extrinsic},
         txFee,
         coreAssetId,
         userAssetBalance,
@@ -80,7 +80,8 @@ function checkUserBalanceForFee(props: LiquidityProps, errors: FormErrors): stri
     const feeAmount = coreAssetId === feeAssetId ? txFee.feeInCpay : txFee.feeInFeeAsset;
     let balRequired = feeAmount;
 
-    if (coreAmount && balRequired) {
+    // Add core amount to the fee only for add liquidity operation
+    if (extrinsic === ADD_LIQUIDITY && coreAmount && balRequired) {
         balRequired = new Amount(balRequired.add(coreAmount));
     }
     const assetBalance = userAssetBalance.find(


### PR DESCRIPTION
Issue reported by Mike and Amy (withdraw liquidity)
![image](https://user-images.githubusercontent.com/29415595/123572479-6893c580-d820-11eb-9eb1-3c2bb4f0d993.png)

![image](https://user-images.githubusercontent.com/29415595/123561194-23a96800-d7fb-11eb-96a1-a168a159b5e3.png)

External link is used to show the txHash... As the chain grows bigger, this value can get really big.. Added css to truncate the text...
<img width="1779" alt="Screen Shot 2021-06-28 at 10 13 36 AM" src="https://user-images.githubusercontent.com/29415595/123561146-e5ac4400-d7fa-11eb-987b-36ac4560f553.png">
