### PR TITLE
Updated uncover link to use block tab over extrinsic tab

### DIFF
--- a/src/components/Dialog/TxDialog/TxDialogBody.tsx
+++ b/src/components/Dialog/TxDialog/TxDialogBody.tsx
@@ -12,7 +12,7 @@ import SummaryFee from '../../AdvancedSetting/SummaryFee';
 
 type AssetSwapParams = [number, number, Amount, Amount];
 
-const getCennzScanURL = txHash => `https://www.uncoverexplorer.com/block/${txHash}`;
+const getCennzScanURL = txHash => `https://www.uncoverexplorer.com/extrinsic/${txHash}`;
 
 const BodyForBroadcasted: FC<{txHash: string}> = ({txHash}) => (
     <div>
@@ -95,7 +95,7 @@ const BodyForFinalised: FC<BodyForFinalisedProps> = ({
                           Amount.ROUND_UP
                       )}  ${assetInfo[feeExchangeResult.assetId].symbol}`
                     : ''}
-                <br /> Block hash:
+                <br /> Transaction hash:
                 <ExternalLink url={getCennzScanURL(txHash)} text={txHash} />
             </div>
         );

--- a/src/components/Dialog/TxDialog/TxDialogBody.tsx
+++ b/src/components/Dialog/TxDialog/TxDialogBody.tsx
@@ -12,7 +12,7 @@ import SummaryFee from '../../AdvancedSetting/SummaryFee';
 
 type AssetSwapParams = [number, number, Amount, Amount];
 
-const getCennzScanURL = txHash => `https://www.uncoverexplorer.com/extrinsic/${txHash}`;
+const getCennzScanURL = txHash => `https://www.uncoverexplorer.com/block/${txHash}`;
 
 const BodyForBroadcasted: FC<{txHash: string}> = ({txHash}) => (
     <div>
@@ -95,7 +95,7 @@ const BodyForFinalised: FC<BodyForFinalisedProps> = ({
                           Amount.ROUND_UP
                       )}  ${assetInfo[feeExchangeResult.assetId].symbol}`
                     : ''}
-                <br /> Transaction hash:
+                <br /> Block hash:
                 <ExternalLink url={getCennzScanURL(txHash)} text={txHash} />
             </div>
         );

--- a/src/redux/epics/txDialog/submitTransaction.epic.ts
+++ b/src/redux/epics/txDialog/submitTransaction.epic.ts
@@ -86,10 +86,7 @@ export const submitTransactionEpic = (
                             return tx.signAndSend(signingAccount, {signer}).pipe(
                                 switchMap(({events, status}: SubmittableResult) => {
                                     if (status.isInBlock) {
-                                        return of(
-                                            updateTxHash(status.asInBlock.toString()),
-                                            updateStage(Stages.InBlock)
-                                        );
+                                        return of(updateTxHash(tx.hash.toString()), updateStage(Stages.InBlock));
                                     } else if (status.isFinalized && events) {
                                         return of(updateTxEvents(events), updateStage(Stages.Finalised));
                                     } else {
@@ -161,7 +158,7 @@ export const submitLiquidityEpic = (
                                 switchMap(({events, status}) => {
                                     if (status.isInBlock) {
                                         return of(
-                                            updateTxHash(status.asInBlock.toString()),
+                                            updateTxHash(tx.hash.toString()),
                                             updateStage(Stages.InBlock),
                                             resetLiquidity(),
                                             updateExtrinsic(extrinsic.method)


### PR DESCRIPTION
Fixes issue reported by @Amy-Centrality 

There's a report of transaction completed on CENNZX, but then UNcover shows it as fail. Any idea why this would be? https://www.uncoverexplorer.com/extrinsic/0xcab35dfbabbce9c8d6710e3c555fc366c75f11b0f6ec04335c23e8ae7299e252