### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push-develop.yml
+++ b/.github/workflows/push-develop.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out from Git
         uses: actions/checkout@master
       - name: Publish Docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{env.DOCKERHUB_REPOSITORY}}
           username: ${{ env.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore